### PR TITLE
Add test for mutable/mongo adapter

### DIFF
--- a/tests/behat/features/access-control-mutable.feature
+++ b/tests/behat/features/access-control-mutable.feature
@@ -1,0 +1,60 @@
+Feature: Imbo features access control backed by a MongoDB database
+    In order to get content from Imbo
+    As an HTTP Client
+    I must specify a public key in the URI or request headers
+
+    Background:
+        Given Imbo uses the "access-control-mutable.php" configuration
+        And I prime the database with "access-control-mutable.php"
+
+    Scenario: Request an access-controlled resource under an unknown user
+        When I request "/users/user1337.json"
+        Then I should get a response with "400 Permission denied (public key)"
+
+    Scenario: Request an access-controlled resource with no public key specified
+        When I request "/users/foobar.json"
+        Then I should get a response with "400 Permission denied (public key)"
+
+    Scenario: Request an access-controlled resource with invalid public key specified
+        Given I use "invalid" and "foobar" for public and private keys
+        And I include an access token in the query
+        When I request "/users/user1.json"
+        Then I should get a response with "400 Permission denied (public key)"
+        And the Imbo error message is "Permission denied (public key)" and the error code is "0"
+
+    Scenario: Request an access-controlled resource with public key that does not have access to the user
+        Given I use "valid-pubkey" and "foobar" for public and private keys
+        And I include an access token in the query
+        When I request "/users/user2.json"
+        Then I should get a response with "400 Permission denied (public key)"
+        And the Imbo error message is "Permission denied (public key)" and the error code is "0"
+
+    Scenario: Request an access-controlled resource with valid public key specified
+        Given I use "foobar" and "barfoo" for public and private keys
+        And I include an access token in the query
+        When I request "/users/foobar/images.json"
+        Then I should get a response with "200 OK"
+
+    Scenario: Request an access-controlled resource with group that does not contain the resource
+        Given I use "valid-group-pubkey" and "foobar" for public and private keys
+        And I include an access token in the query
+        When I request "/users/user/images/9c554794f784778cd436064faa2ea24a"
+        Then I should get a response with "400 Permission denied (public key)"
+
+    Scenario: Request user information when access is granted through a group
+        Given I use "group-based" and "foobar" for public and private keys
+        And I include an access token in the query
+        When I request "/users/user1"
+        Then I should get a response with "200 OK"
+
+    Scenario: Request user information when resource is granted but not for the given user
+        Given I use "group-based" and "foobar" for public and private keys
+        And I include an access token in the query
+        When I request "/users/other-user"
+        Then I should get a response with "400 Permission denied (public key)"
+
+    Scenario: Request user information when access is granted through a wildcard
+        Given I use "wildcarded" and "foobar" for public and private keys
+        And I include an access token in the query
+        When I request "/users/random-user"
+        Then I should get a response with "200 OK"

--- a/tests/behat/features/access-control.feature
+++ b/tests/behat/features/access-control.feature
@@ -92,30 +92,3 @@ Feature: Imbo provides a way to access control resources on a per-public key bas
         And Imbo uses the "custom-access-control.php" configuration
         When I request "/users/public"
         Then I should get a response with "200 OK"
-
-    Scenario: Request user information when access is granted through a group
-        Given Imbo uses the "access-control-mutable.php" configuration
-        And I prime the database with "access-control-mutable.php"
-        And I use "group-based" and "foobar" for public and private keys
-        And I include an access token in the query
-        And Imbo uses the "access-control-mutable.php" configuration
-        When I request "/users/user1"
-        Then I should get a response with "200 OK"
-
-    Scenario: Request user information when resource is granted but not for the given user
-        Given Imbo uses the "access-control-mutable.php" configuration
-        And I prime the database with "access-control-mutable.php"
-        And I use "group-based" and "foobar" for public and private keys
-        And I include an access token in the query
-        And Imbo uses the "access-control-mutable.php" configuration
-        When I request "/users/other-user"
-        Then I should get a response with "400 Permission denied (public key)"
-
-    Scenario: Request user information when access is granted through a wildcard
-        Given Imbo uses the "access-control-mutable.php" configuration
-        And I prime the database with "access-control-mutable.php"
-        And I use "wildcarded" and "foobar" for public and private keys
-        And I include an access token in the query
-        And Imbo uses the "access-control-mutable.php" configuration
-        When I request "/users/random-user"
-        Then I should get a response with "200 OK"

--- a/tests/behat/fixtures/access-control-mutable.php
+++ b/tests/behat/fixtures/access-control-mutable.php
@@ -35,8 +35,8 @@ return [
             'privateKey' => 'barfoo',
             'acl' => [[
                 'id' => new MongoId('100000000000000000001337'),
-                'resources' => ['access.get', 'access.head'],
-                'users' => []
+                'resources' => ['access.get', 'access.head', 'images.get'],
+                'users' => ['foobar']
             ]]
         ],
         [


### PR DESCRIPTION
While debugging a case where I got hash mismatch errors I added a few tests for the usual operations a user would do, but running with a mutable access control adapter. It turned out however that the error was in BIG-IP and not in Imbo.

The tests will probably not hurt anyway. Also moved a few of the mutable adapter tests from `access-control.feature` into `access-control-mutable.feature`.
